### PR TITLE
Replace new Net::Patricia by Net::Patricia->new

### DIFF
--- a/Patricia.pm
+++ b/Patricia.pm
@@ -323,8 +323,9 @@ Net::Patricia - Patricia Trie perl module for fast IP address lookups
 
   use Net::Patricia;
 
-  my $pt = new Net::Patricia;
+  my $pt = Net::Patricia->new;
 
+  my $user_data;
   $pt->add_string('127.0.0.0/8', \$user_data);
   $pt->match_string('127.0.0.1');
   $pt->match_exact_string('127.0.0.0');
@@ -336,7 +337,7 @@ Net::Patricia - Patricia Trie perl module for fast IP address lookups
   undef $pt; # automatically destroys the Patricia Trie
 
   # IPv6 support:
-  $pt = new Net::Patricia AF_INET6;
+  $pt = Net::Patricia->new(AF_INET6);
   $pt->add_string('2001:db8::/32');
   $pt->add_string('2001:db8:0:dead::/64');
   $pt->add_string('2001:db8:0:beef::/64');
@@ -377,7 +378,7 @@ Routing Table for Berkeley Unix'' by Keith Sklower.
 
 =item B<new> - create a new Net::Patricia object
 
-   $pt = new Net::Patricia;
+   $pt = Net::Patricia->new;
 
 This is the class' constructor - it returns a C<Net::Patricia> object
 upon success or undef on failure.  The constructor takes an

--- a/t/01everything.t
+++ b/t/01everything.t
@@ -16,7 +16,7 @@ plan tests => 48;
 # (correspondingly "not ok 13") depending on the success of chunk 13
 # of the test code):
 
-my $t = new Net::Patricia;
+my $t = Net::Patricia->new;
 
 isa_ok($t, 'Net::Patricia', 'creating base object');
 
@@ -35,8 +35,8 @@ for my $o ({ name => "original", obj => $t }, { name => "thawed", obj => $thawed
 }
 
 {
-   my $ten = new Thingy 10;
-   my $twenty = new Thingy 20;
+   my $ten = Thingy->new(10);
+   my $twenty = Thingy->new(20);
 ok($t->add_string("10.0.0.0/8", $ten), "adding 10.0.0.0/8");
 }
 
@@ -108,7 +108,7 @@ is(@a, 2, "removing cidr block");
 
 undef $t;
 
-$t = new Net::Patricia(AF_INET6);
+$t = Net::Patricia->new(AF_INET6);
 
 isa_ok($t, "Net::Patricia::AF_INET6", "constructing a Net::Patrica::AF_INET6");
 


### PR DESCRIPTION
This pull request modernizes the examples and tests by replacing `new Net::Patricia` with `Net::Patricia->new`.