### PR TITLE
Modernize Makefile.PL

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,39 +1,63 @@
+use strict;
+use warnings;
+
 use 5.008;
 use ExtUtils::MakeMaker;
 
-my $mm_ver = $ExtUtils::MakeMaker::VERSION;
-if ($mm_ver =~ /_/) { # dev version
-    $mm_ver = eval $mm_ver;
-    die $@ if $@;
-}
-
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
-WriteMakefile(
-    'NAME'	=> 'Net::Patricia',
-    'VERSION_FROM' => 'Patricia.pm', # finds $VERSION
-    'LIBS'	=> [],     # e.g., '-lm' 
-    'DEFINE'	=> '',     # e.g., '-DHAVE_SOMETHING' 
-    'INC'	=> '',     # e.g., '-I/usr/include/other' 
-    'MYEXTLIB'	=> 'libpatricia/libpatricia$(LIB_EXT)',     # e.g., '-I/usr/include/other' 
-    'dist'      => {'COMPRESS'=>'gzip -9f', 'SUFFIX' => 'gz'},
-    'PREREQ_PM'	=> {'Socket6' => 0,
-		    'version' => 0,
-		    'Test::More' => '0.88',
-		    'Net::CIDR::Lite' => '0.20',
-		   },
-    ($mm_ver <= 6.45 ? () : (META_MERGE => {
-        'meta-spec' => { version => 2 },
-        resources => {
-            bugtracker  =>      'http://rt.cpan.org/Public/Dist/Display.html?Name=Net-Patricia',
-            repository  => {
+my %WriteMakefileArgs = (
+    'NAME'         => 'Net::Patricia',
+    'VERSION_FROM' => 'Patricia.pm',     # finds $VERSION
+    'ABSTRACT'     => 'Patricia Trie for fast IP address lookups',
+    'AUTHOR'       => 'Dave Plonka <plonka@doit.wisc.edu>',
+    'LICENSE'      => 'gpl_2',           # and BSD two-clause (see below)
+    'MYEXTLIB'     => 'libpatricia/libpatricia$(LIB_EXT)',
+    'PREREQ_PM'    => {
+        'Carp'            => 0,
+        'DynaLoader'      => 0,
+        'Exporter'        => 0,
+        'Net::CIDR::Lite' => '0.20',
+        'Socket'          => 0,
+        'Socket6'         => 0,
+        'version'         => 0,
+    },
+    'TEST_REQUIRES' => {
+        'Storable'   => 0,
+        'Test::More' => '0.88',
+    },
+    META_MERGE => {
+        'meta-spec' => {version => 2},
+        license     => ['freebsd'],
+        resources   => {
+            bugtracker => {
+                web =>
+                    'http://rt.cpan.org/Public/Dist/Display.html?Name=Net-Patricia',
+            },
+            repository => {
                 type => 'git',
                 web  => 'https://github.com/tobez/Net-Patricia',
                 url  => 'git://github.com/tobez/Net-Patricia.git',
             },
         },
-    })),
+    },
 );
+
+my %FallbackPrereqs = (
+    %{$WriteMakefileArgs{PREREQ_PM}},
+    %{$WriteMakefileArgs{TEST_REQUIRES}},
+);
+
+unless (eval { ExtUtils::MakeMaker->VERSION('6.63_03') }) {
+    delete $WriteMakefileArgs{TEST_REQUIRES};
+    $WriteMakefileArgs{PREREQ_PM} = \%FallbackPrereqs;
+}
+
+unless (eval { ExtUtils::MakeMaker->VERSION(6.46) }) {
+    delete $WriteMakefileArgs{META_MERGE};
+}
+
+WriteMakefile(%WriteMakefileArgs);
 
 sub MY::postamble {
 '


### PR DESCRIPTION
This pull request adds ABSTRACT, AUTHOR, LICENSE and TEST_REQUIRES keys to Makefile.PL with fallbacks for old ExtUtils::MakeMaker versions.

The PR also fixes the bugtracker entry. The bugtracker entry points to rt.cpan.org. The URL could be changed to `https://github.com/tobez/Net-Patricia/issues` instead.