### PR TITLE
Remove the check for an invalid key

### DIFF
--- a/t/01everything.t
+++ b/t/01everything.t
@@ -10,7 +10,7 @@ use Storable;
 
 our $debug = 1;
 
-plan tests => 48;
+plan tests => 47;
 
 # Insert your test code below (better if it prints "ok 13"
 # (correspondingly "not ok 13") depending on the success of chunk 13
@@ -82,9 +82,6 @@ for my $o ({ name => "original", obj => $t }, { name => "thawed", obj => $thawed
 
     ok($o->{obj}->climb, "$o->{name}: climb");
 }
-
-eval '$t->add_string("_")'; # invalid key
-like($@, qr/invalid/, 'adding "_"');
 
 ok($t->add_string("0.0.0.0/0"), "add 0.0.0.0/0");
 


### PR DESCRIPTION
A test uses "_" as an invalid IP address and fails on systems that resolve unknown hostnames to IP addresses. This pull request removes the test as there doesn't seem to be a string that ist both an invalid IP address and an invalid hostname on all possible systems. Fixes #11.