### PR TITLE
Update the GitHub Actions

### DIFF
--- a/.github/workflows/make_test.yml
+++ b/.github/workflows/make_test.yml
@@ -21,15 +21,23 @@ jobs:
             perl: "5.8"
       fail-fast: false
     env:
-      MODULES: ${{ matrix.perl == '5.8' && 'Socket6 Net::CIDR::Lite Test::More version' || 'Socket6 Net::CIDR::Lite' }}
+      MAKECMD: ${{ (matrix.os == 'windows-latest' && matrix.perl == '5.20' && 'dmake') || (matrix.os == 'windows-latest' && 'gmake') || 'make' }}
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v5
       - uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl }}
-          install-modules-with: cpanm
-          install-modules: ${{ env.MODULES }}
+          distribution: ${{ matrix.os == 'windows-latest' && 'strawberry' || 'default' }}
+      - run: |
+          touch cpanfile
+          echo 'requires "Net::CIDR::Lite" => "0";' >> cpanfile
+          echo 'requires "Socket" => "0";' >> cpanfile
+          echo 'requires "Socket6" => "0";' >> cpanfile
+          echo 'requires "Test::More" => "0.88";' >> cpanfile
+          echo 'requires "Test::Pod" => "1.00";' >> cpanfile
+          echo 'requires "version" => "0";' >> cpanfile
+      - run: cpanm --insecure --installdeps .
       - run: perl Makefile.PL
-      - run: make
-      - run: make test
+      - run: ${{ env.MAKECMD }}
+      - run: ${{ env.MAKECMD }} test TEST_VERBOSE=1

--- a/.github/workflows/make_test.yml
+++ b/.github/workflows/make_test.yml
@@ -24,7 +24,7 @@ jobs:
       MODULES: ${{ matrix.perl == '5.8' && 'Socket6 Net::CIDR::Lite Test::More version' || 'Socket6 Net::CIDR::Lite' }}
     name: Perl ${{ matrix.perl }} on ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: shogo82148/actions-setup-perl@v1
         with:
           perl-version: ${{ matrix.perl }}


### PR DESCRIPTION
Currently, the GitHub-hosted Windows runners cannot build the Socket6 module. See [#140028](https://rt.cpan.org/Public/Bug/Display.html?id=140028) for more information.

Strawberry Perl provides a patched Socket6 module. This pull request updates the GitHub Actions to use Strawberry Perl on Windows. A cpanfile is created in order to install Net::Patricia's dependencies. cpanm is called with --insecure as Strawberry Perl 5.20 provides outdated CA certificates. The pull request also updates actions/checkout. The tests are now run with TEST_VERBOSE=1.