### PR TITLE
Add a license heading

### DIFF
--- a/Patricia.pm
+++ b/Patricia.pm
@@ -577,6 +577,8 @@ Philip Prindeville <philipp@redfish-solutions.com>
 
 Anton Berezin <tobez@tobez.org>
 
+=head1 LICENSE AND COPYRIGHT
+
 Copyright (C) 2000-2005  Dave Plonka.  Copyright (C) 2009  Dave Plonka
 & Philip Prindeville.  This program is free software; you
 can redistribute it and/or modify it under the terms of the GNU General


### PR DESCRIPTION
The Kwalitee tests run by CPANTS report a missing license heading. This pull request adds the heading to Patricia.pm.